### PR TITLE
Add "Delay" effect

### DIFF
--- a/kiro-synth-core/src/effects/delay.rs
+++ b/kiro-synth-core/src/effects/delay.rs
@@ -80,3 +80,48 @@ impl<'a, F: Float> Delay<'a, F> {
     sample * self.mix + input * (F::val(1.0) - self.mix)
   }
 }
+
+#[cfg(test)]
+mod test {
+  use super::*;
+  use assert_approx_eq::assert_approx_eq;
+
+  #[test]
+  fn delayline_get() {
+    let mut buffer = [4., 3., 2., 1.];
+    // let delayline = DelayLine::new(1.0, &mut buffer);
+    let delayline = DelayLine {
+      head: 1,
+      buffer: &mut buffer,
+    };
+
+    assert_approx_eq!(delayline.get(1), 4.0f64);
+    assert_approx_eq!(delayline.get(2), 1.0f64);
+    assert_approx_eq!(delayline.get(3), 2.0f64);
+    assert_approx_eq!(delayline.get(4), 3.0f64);
+    assert_approx_eq!(delayline.get(5), 3.0f64);
+    assert_approx_eq!(delayline.get(6), 3.0f64);
+  }
+
+  #[test]
+  fn delayline_update() {
+    let mut buffer = [0.; 4];
+    let mut delayline = DelayLine {
+      head: 1,
+      buffer: &mut buffer,
+    };
+
+    delayline.update(1.0);
+    delayline.update(2.0);
+    delayline.update(3.0);
+    delayline.update(4.0);
+
+    let DelayLine { head: _, buffer } = delayline;
+    buffer
+      .iter()
+      .zip([4.0f64, 1.0f64, 2.0f64, 3.0f64].iter())
+      .for_each(|(a, b)| {
+        assert_approx_eq!(a, b);
+      });
+  }
+}

--- a/kiro-synth-core/src/effects/delay.rs
+++ b/kiro-synth-core/src/effects/delay.rs
@@ -27,7 +27,7 @@ impl<'a, F: Float> DelayLine<'a, F> {
   }
 }
 
-/// Simple delay effect with 3 parameters: the delay amount, the amount of feedback and dry/run mix.
+/// Simple delay effect with 3 parameters: the delay amount, the amount of feedback and dry/wet mix.
 pub struct Delay<'a, F: Float> {
   /// The amount of delay for the output signal. Values from `1.0 / sample_rate` to `buffer.len() / sample_rate`.
   delay_seconds: F,

--- a/kiro-synth-core/src/effects/delay.rs
+++ b/kiro-synth-core/src/effects/delay.rs
@@ -35,7 +35,6 @@ pub struct Delay<'a, F: Float> {
   feedback: F,
   /// The dry/wet proportion. Values from 0.0 (dry) to 1.0 (wet)
   mix: F,
-  
   sample_rate: F,
   delayline: DelayLine<'a, F>,
   delay_samples: usize,

--- a/kiro-synth-core/src/effects/delay.rs
+++ b/kiro-synth-core/src/effects/delay.rs
@@ -1,0 +1,77 @@
+use crate::float::Float;
+use std::collections::VecDeque;
+
+struct DelayLine<F: Float> {
+  sample_rate: F,
+  buffer: VecDeque<F>,
+}
+
+impl<F: Float> DelayLine<F> {
+  pub fn new(sample_rate: F) -> Self {
+    let delay_max = F::val(2.0);
+    let len = (sample_rate * delay_max).ceil().to_usize().unwrap();
+    Self {
+      sample_rate,
+      buffer: VecDeque::<F>::with_capacity(len),
+    }
+  }
+
+  pub fn update(&mut self, input: F) {
+    self.buffer.pop_front();
+    self.buffer.push_back(input);
+  }
+
+  pub fn get(&self, index: F) -> F {
+    let index = (index * self.sample_rate).to_usize().unwrap();
+    *self.buffer.iter().nth_back(index).unwrap_or(&F::zero())
+  }
+}
+
+pub struct Delay<F: Float> {
+  delay: F,
+  feedback: F,
+  mix: F,
+  delayline: DelayLine<F>,
+}
+
+impl<F: Float> Delay<F> {
+  pub fn new(sample_rate: F) -> Self {
+    Self {
+      delay: F::one(),     // delay in seconds NOTE it must never be 0
+      feedback: F::zero(), // between 0 and 1
+      mix: F::zero(),      // between 0 and 1
+      delayline: DelayLine::<F>::new(sample_rate),
+    }
+  }
+
+  pub fn set_delay(&mut self, delay: F) {
+    self.delay = delay
+  }
+
+  pub fn get_delay(&self) -> F {
+    self.delay
+  }
+
+  pub fn set_feedback(&mut self, feedback: F) {
+    self.feedback = feedback;
+  }
+
+  pub fn get_feedback(&self) -> F {
+    self.feedback
+  }
+
+  pub fn set_mix(&mut self, mix: F) {
+    self.mix = mix;
+  }
+
+  pub fn get_mix(&self) -> F {
+    self.mix
+  }
+
+  pub fn process(&mut self, input: F) -> F {
+    let sample = self.delayline.get(self.delay);
+    self.delayline.update(input + sample * self.feedback);
+
+    sample * self.mix + input * (F::val(1.0) - self.mix)
+  }
+}

--- a/kiro-synth-core/src/effects/delay.rs
+++ b/kiro-synth-core/src/effects/delay.rs
@@ -1,55 +1,60 @@
 use crate::float::Float;
-use std::collections::VecDeque;
 
-struct DelayLine<F: Float> {
-  sample_rate: F,
-  buffer: VecDeque<F>,
+struct DelayLine<'a, F: Float> {
+  head: usize,
+  buffer: &'a mut [F],
 }
 
-impl<F: Float> DelayLine<F> {
-  pub fn new(sample_rate: F) -> Self {
-    let delay_max = F::val(2.0);
-    let len = (sample_rate * delay_max).ceil().to_usize().unwrap();
-    Self {
-      sample_rate,
-      buffer: VecDeque::<F>::with_capacity(len),
-    }
+impl<'a, F: Float> DelayLine<'a, F> {
+  pub fn new(buffer: &'a mut [F]) -> Self {
+    Self { head: 0, buffer }
   }
 
   pub fn update(&mut self, input: F) {
-    self.buffer.pop_front();
-    self.buffer.push_back(input);
+    self.buffer[self.head] = input;
+    self.head = (self.head + 1) % self.buffer.len();
   }
 
-  pub fn get(&self, index: F) -> F {
-    let index = (index * self.sample_rate).to_usize().unwrap();
-    *self.buffer.iter().nth_back(index).unwrap_or(&F::zero())
+  pub fn get(&self, delay_samples: usize) -> F {
+    let offset = self.buffer.len().min(delay_samples);
+
+    let index = if offset > self.head {
+      self.buffer.len() - offset + self.head
+    } else {
+      self.head - offset
+    };
+    self.buffer[index]
   }
 }
 
-pub struct Delay<F: Float> {
-  delay: F,
+pub struct Delay<'a, F: Float> {
+  delay_samples: usize,
+  delay_seconds: F,
   feedback: F,
   mix: F,
-  delayline: DelayLine<F>,
+  delayline: DelayLine<'a, F>,
+  sample_rate: F,
 }
 
-impl<F: Float> Delay<F> {
-  pub fn new(sample_rate: F) -> Self {
+impl<'a, F: Float> Delay<'a, F> {
+  pub fn new(sample_rate: F, buffer: &'a mut [F]) -> Self {
     Self {
-      delay: F::one(),     // delay in seconds NOTE it must never be 0
+      delay_samples: 1, // delay in samples NOTE it must never be 0
+      delay_seconds: F::val(1) / sample_rate,
       feedback: F::zero(), // between 0 and 1
       mix: F::zero(),      // between 0 and 1
-      delayline: DelayLine::<F>::new(sample_rate),
+      delayline: DelayLine::<F>::new(buffer),
+      sample_rate,
     }
   }
 
-  pub fn set_delay(&mut self, delay: F) {
-    self.delay = delay
+  pub fn set_delay_seconds(&mut self, delay_seconds: F) {
+    self.delay_seconds = delay_seconds;
+    self.delay_samples = (delay_seconds * self.sample_rate).to_usize().unwrap()
   }
 
-  pub fn get_delay(&self) -> F {
-    self.delay
+  pub fn get_delay_seconds(&self) -> F {
+    self.delay_seconds
   }
 
   pub fn set_feedback(&mut self, feedback: F) {
@@ -69,7 +74,7 @@ impl<F: Float> Delay<F> {
   }
 
   pub fn process(&mut self, input: F) -> F {
-    let sample = self.delayline.get(self.delay);
+    let sample = self.delayline.get(self.delay_samples);
     self.delayline.update(input + sample * self.feedback);
 
     sample * self.mix + input * (F::val(1.0) - self.mix)

--- a/kiro-synth-core/src/effects/mod.rs
+++ b/kiro-synth-core/src/effects/mod.rs
@@ -1,0 +1,1 @@
+use crate::float::Float;

--- a/kiro-synth-core/src/effects/mod.rs
+++ b/kiro-synth-core/src/effects/mod.rs
@@ -1,1 +1,1 @@
-
+pub mod delay;

--- a/kiro-synth-core/src/effects/mod.rs
+++ b/kiro-synth-core/src/effects/mod.rs
@@ -1,1 +1,1 @@
-use crate::float::Float;
+

--- a/kiro-synth-core/src/lib.rs
+++ b/kiro-synth-core/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod blep;
 pub mod dca;
+pub mod effects;
 pub mod envgen;
 pub mod filters;
 pub mod float;


### PR DESCRIPTION
Adding a simple Delay effect.
The buffer allocation responsibility is delegated to the user of the lib (to avoid heap allocation and keep compatibility with no_std and embedded).